### PR TITLE
add quotes around booleans in config

### DIFF
--- a/addons/main/CfgDialogs.hpp
+++ b/addons/main/CfgDialogs.hpp
@@ -97,7 +97,7 @@ class ScreenItemXResult: RscText
 class ConfigureScreenDialog
 {
 	idd = 14631;
-	enableSimulation = true;
+	enableSimulation = "true";
 
     onUnload = "['onUnloadDialog', _this] call WR_main_fnc_ui_configureScreen;";
 
@@ -596,7 +596,7 @@ class ConfigureScreenDialog
 class ConfigureScreenImageItemDialog
 {
 	idd = 14632;
-	enableSimulation = true;
+	enableSimulation = "true";
 
     onUnload = "['onUnloadDialog', _this] call WR_main_fnc_ui_configureScreenImageItem;";
 
@@ -765,7 +765,7 @@ class ConfigureScreenImageItemDialog
 class ConfigureScreenTextItemDialog
 {
 	idd = 14633;
-	enableSimulation = true;
+	enableSimulation = "true";
 
     onUnload = "['onUnloadDialog', _this] call WR_main_fnc_ui_configureScreenTextItem;";
 
@@ -874,7 +874,7 @@ class ConfigureScreenTextItemDialog
 class ConfigureScreenMapItemDialog
 {
 	idd = 14634;
-	enableSimulation = true;
+	enableSimulation = "true";
 
     onUnload = "['onUnloadDialog', _this] call WR_main_fnc_ui_configureScreenMapItem;";
 
@@ -1008,7 +1008,7 @@ class ConfigureScreenMapItemDialog
 class ConfigureScreenCamItemDialog
 {
 	idd = 14635;
-	enableSimulation = true;
+	enableSimulation = "true";
 
     onUnload = "['onUnloadDialog', _this] call WR_main_fnc_ui_configureScreenCamItem;";
 
@@ -1101,7 +1101,7 @@ class WarRoomTemplate40by25
 {
 	idd = -1;
 
-	enableSimulation = true;
+	enableSimulation = "true";
 
 	WR_uiScreenItemCount = -1;
 
@@ -1202,7 +1202,7 @@ class WarRoomTemplate40by25Mod1
 
 	idd = -1;
 
-	enableSimulation = true;
+	enableSimulation = "true";
 
 	WR_uiScreenItemCount = -1;
 
@@ -1303,7 +1303,7 @@ class WarRoomTemplate40by25Mod2
 
 	idd = -1;
 
-	enableSimulation = true;
+	enableSimulation = "true";
 
 	WR_uiScreenItemCount = -1;
 
@@ -1404,7 +1404,7 @@ class WarRoomTemplate40by25Mod3
 
 	idd = -1;
 
-	enableSimulation = true;
+	enableSimulation = "true";
 
 	WR_uiScreenItemCount = -1;
 


### PR DESCRIPTION
enables building with HEMTT 1.12.5

without it one gets many errors
```powershell
PS C:\Users\Bernhard-WS\Documents\GitHub\GruppeAdler\war-room> hemtt build    
 INFO HEMTT 1.12.5 is available, please update
 INFO Config loaded for War Room 0.1.0.0-4536c9b7
 INFO Creating `build` version
 INFO Rapified 1 addon configs
error[CE1]: property's value could not be parsed.
    ┌─ addons/main/CfgDialogs.hpp:100:21
    │
100 │     enableSimulation = true;
    │                        ^^^^ invalid value  
    │
    = help: use quotes `"` around the value      


error[CE1]: property's value could not be parsed.
    ┌─ addons/main/CfgDialogs.hpp:599:21
    │
599 │     enableSimulation = true;
    │                        ^^^^ invalid value
    │
    = help: use quotes `"` around the value


error[CE1]: property's value could not be parsed.
    ┌─ addons/main/CfgDialogs.hpp:768:21
    │
768 │     enableSimulation = true;
    │                        ^^^^ invalid value
    │
    = help: use quotes `"` around the value


error[CE1]: property's value could not be parsed.
    ┌─ addons/main/CfgDialogs.hpp:877:21
    │
877 │     enableSimulation = true;
    │                        ^^^^ invalid value
    │
    = help: use quotes `"` around the value


error[CE1]: property's value could not be parsed.
     ┌─ addons/main/CfgDialogs.hpp:1011:21
     │
1011 │     enableSimulation = true;
     │                        ^^^^ invalid value
     │
     = help: use quotes `"` around the value


error[CE1]: property's value could not be parsed.
     ┌─ addons/main/CfgDialogs.hpp:1104:21
     │
1104 │     enableSimulation = true;
     │                        ^^^^ invalid value
     │
     = help: use quotes `"` around the value


error[CE1]: property's value could not be parsed.
     ┌─ addons/main/CfgDialogs.hpp:1205:21
     │
1205 │     enableSimulation = true;
     │                        ^^^^ invalid value
     │
     = help: use quotes `"` around the value


error[CE1]: property's value could not be parsed.
     ┌─ addons/main/CfgDialogs.hpp:1306:21
     │
1306 │     enableSimulation = true;
     │                        ^^^^ invalid value
     │


error[CE1]: property's value could not be parsed.
     ┌─ addons/main/CfgDialogs.hpp:1407:21
     │
1407 │     enableSimulation = true;
     │                        ^^^^ invalid value
     │
     = help: use quotes `"` around the value


PS C:\Users\Bernhard-WS\Documents\GitHub\GruppeAdler\war-room>
```